### PR TITLE
HOTFIX: Add CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ before:
 builds:
 - id: crystal-ball
   main: ./cmd/crystal-ball
+  env:
+    - CGO_ENABLED=0
   goos:
   - linux
   goarch:


### PR DESCRIPTION
On #33 it was an issue, the resulting container image contains a binary witch was not statically built. As it required some system dependencies to run would be better to statically build it.

Here is the fix. Adding `CGO_ENABLED=0` to the build phase solves the issue.
Tested from my fork:

```
$ docker run -ti --rm ghcr.io/angelbarrera92/crystal-ball:v0.2.7 /bin/sh
/orakuru # /bin/crystal-ball
12:14PM INF ../home/runner/work/crystal-ball/crystal-ball/cmd/crystal-ball/main.go:41 > starting crystall-ball
Version: 0.2.7
Commit: 62d60b1169b4b1ec03ff698cfe7f03cabae9288e
Date: 2021-06-02T12:12:55Z
12:14PM FTL ../home/runner/work/crystal-ball/crystal-ball/cmd/crystal-ball/main.go:46 > failed to open requests configuration error="open etc/requests.yml: no such file or directory"
```

Sorry for the issue 🙏🙏🙏🙏🙏🙏 